### PR TITLE
chore: support go 1.26 toolchain

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,15 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.24.2
+          go-version: 1.26.x
       - name: Fetch Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Tidy
         run: make tidy
+      - name: Install golangci-lint
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.6.2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
-        with:
-          version: v2.0
-          args: --timeout=5m ./runtime/...
+        run: make lint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,13 +9,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [ '1.24']
+        go: [ '1.26.x']
         os: [ ubuntu-latest ]
     name: ${{ matrix.os }} Go ${{ matrix.go }} Tests
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
       - name: Install gotestsum

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ pulls in Hookr as a normal Go module dependency.
 
 ### Prerequisites
 
-- Go 1.24 or higher
-- TinyGo 0.30.0 or higher (for building plugins)
+- Go 1.26 or higher
+- TinyGo 0.41.0 or higher (for building plugins)
 
 ## What Hookr Is For
 

--- a/docs/agent-index.md
+++ b/docs/agent-index.md
@@ -43,6 +43,7 @@ Use this order when building context from scratch:
 
 - [README](https://github.com/mopeyjellyfish/hookr/blob/main/README.md)
 - [CLI Reference](/reference/cli)
+- requires Go 1.26 or higher
 - command: `go install github.com/mopeyjellyfish/hookr/cmd/hookr@latest`
 - command: `hookr version`
 
@@ -61,6 +62,7 @@ Use this order when building context from scratch:
 ### Build a plugin
 
 - [Build Plugin](/how-to/build-plugin)
+- requires TinyGo 0.41.0 or higher
 - command: `hookr build --plugin ./plugin --out ./bin/plugin.wasm`
 
 ### Open and call a plugin from Go

--- a/docs/how-to/install-toolchain.md
+++ b/docs/how-to/install-toolchain.md
@@ -6,19 +6,21 @@ Install the required CLI and compiler tools for Hookr development.
 
 ## Steps
 
-1. Install Hookr:
+1. Install Go 1.26 or higher.
+
+2. Install Hookr:
 
 ```bash
 go install github.com/mopeyjellyfish/hookr/cmd/hookr@latest
 ```
 
-2. Install FlatBuffers compiler (`flatc`) and TinyGo:
+3. Install FlatBuffers compiler (`flatc`) and TinyGo 0.41.0 or higher:
 
 ```bash
 brew install flatbuffers tinygo
 ```
 
-3. Verify tools:
+4. Verify tools:
 
 ```bash
 hookr --help

--- a/docs/public/agent-index.json
+++ b/docs/public/agent-index.json
@@ -32,6 +32,9 @@
   "tasks": [
     {
       "name": "install-cli",
+      "requires": [
+        "Go 1.26 or higher"
+      ],
       "command": "go install github.com/mopeyjellyfish/hookr/cmd/hookr@latest",
       "docs": [
         "/reference/cli"
@@ -47,6 +50,9 @@
     },
     {
       "name": "build-plugin",
+      "requires": [
+        "TinyGo 0.41.0 or higher"
+      ],
       "command": "hookr build --plugin ./plugin --out ./bin/plugin.wasm",
       "docs": [
         "/how-to/build-plugin"

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -170,7 +170,9 @@ TUI:
 Build and toolchain facts
 
 - Go host support is the primary first-class path.
+- Hookr requires Go 1.26 or higher.
 - TinyGo is the build path for plugins today.
+- Plugin builds require TinyGo 0.41.0 or higher.
 - flatc is required for schema generation and schema-driven JSON conversion.
 - VitePress is used for docs.
 - semantic-release is used for GitHub releases.

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -26,6 +26,7 @@ Core facts:
 - Hookr generates typed Go host SDK and plugin PDK code
 - Runtime validates ABI version, schema hash, capabilities, and methods
 - Trust model uses hash pinning or explicit unsigned opt-in
+- Requires Go 1.26 or higher; plugin builds require TinyGo 0.41.0 or higher
 - CLI commands: gen, build, inspect, call, tui, bench, version
 - Live reload is supported for development through generated SDK config
 

--- a/fixtures_test.go
+++ b/fixtures_test.go
@@ -3,15 +3,15 @@ package hookr
 import (
 	"os/exec"
 	"testing"
+
+	"github.com/mopeyjellyfish/hookr/internal/testutil"
 )
 
 func TestFixtures(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping fixture e2e tests in short mode")
 	}
-	if _, err := exec.LookPath("tinygo"); err != nil {
-		t.Skip("tinygo not installed")
-	}
+	testutil.RequireTinyGo(t)
 
 	packages := []string{
 		"./testdata/contracts/urlbalancer",

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,12 @@
 module github.com/mopeyjellyfish/hookr
 
-go 1.24.2
+go 1.26
 
 require (
 	github.com/charmbracelet/bubbles v0.20.0
 	github.com/charmbracelet/bubbletea v1.3.4
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/fsnotify/fsnotify v1.8.0
 	github.com/google/flatbuffers v25.9.23+incompatible
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
@@ -21,7 +22,6 @@ require (
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
-	github.com/fsnotify/fsnotify v1.8.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
-github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=

--- a/internal/call/call_test.go
+++ b/internal/call/call_test.go
@@ -10,10 +10,12 @@ import (
 	"testing"
 
 	"github.com/mopeyjellyfish/hookr/internal/buildkit"
+	"github.com/mopeyjellyfish/hookr/internal/testutil"
 )
 
 func TestRunTextFilter(t *testing.T) {
 	t.Parallel()
+	testutil.RequireTinyGo(t)
 
 	dir := t.TempDir()
 	wasmPath := filepath.Join(dir, "textfilter.wasm")
@@ -77,6 +79,7 @@ func TestRunTextFilter(t *testing.T) {
 
 func TestRunURLBalancerWithHostFixture(t *testing.T) {
 	t.Parallel()
+	testutil.RequireTinyGo(t)
 
 	dir := t.TempDir()
 	wasmPath := filepath.Join(dir, "urlbalancer.wasm")
@@ -154,6 +157,7 @@ func TestRunURLBalancerWithHostFixture(t *testing.T) {
 
 func TestSessionDefaultRequestJSONUsesSchemaFields(t *testing.T) {
 	t.Parallel()
+	testutil.RequireTinyGo(t)
 
 	dir := t.TempDir()
 	wasmPath := filepath.Join(dir, "textfilter.wasm")
@@ -194,6 +198,7 @@ func TestSessionDefaultRequestJSONUsesSchemaFields(t *testing.T) {
 
 func TestSessionDebugInfo(t *testing.T) {
 	t.Parallel()
+	testutil.RequireTinyGo(t)
 
 	dir := t.TempDir()
 	wasmPath := filepath.Join(dir, "textfilter.wasm")
@@ -232,6 +237,7 @@ func TestSessionDebugInfo(t *testing.T) {
 
 func TestSessionInvokePrepared(t *testing.T) {
 	t.Parallel()
+	testutil.RequireTinyGo(t)
 
 	dir := t.TempDir()
 	wasmPath := filepath.Join(dir, "textfilter.wasm")

--- a/internal/inspect/inspect_test.go
+++ b/internal/inspect/inspect_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/mopeyjellyfish/hookr/internal/buildkit"
+	"github.com/mopeyjellyfish/hookr/internal/testutil"
 )
 
 func TestRunRequiresSchemaPath(t *testing.T) {
@@ -51,6 +52,7 @@ func TestRunPrintsContractDetails(t *testing.T) {
 
 func TestRunPrintsWasmDetails(t *testing.T) {
 	t.Parallel()
+	testutil.RequireTinyGo(t)
 
 	wasmPath := filepath.Join(t.TempDir(), "textfilter.wasm")
 	buildCfg := buildkit.DefaultConfig()

--- a/internal/testutil/tinygo.go
+++ b/internal/testutil/tinygo.go
@@ -1,0 +1,105 @@
+package testutil
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+)
+
+const MinTinyGoVersion = "0.41.0"
+
+var tinyGoCheck struct {
+	once       sync.Once
+	skipReason string
+}
+
+func RequireTinyGo(t testing.TB) {
+	t.Helper()
+
+	tinyGoCheck.once.Do(func() {
+		tinygo, err := exec.LookPath("tinygo")
+		if err != nil {
+			tinyGoCheck.skipReason = "tinygo not installed"
+			return
+		}
+		output, err := exec.Command(tinygo, "version").CombinedOutput()
+		versionText := strings.TrimSpace(string(output))
+		if err != nil {
+			tinyGoCheck.skipReason = fmt.Sprintf("tinygo version failed: %v: %s", err, versionText)
+			return
+		}
+		version, ok := parseTinyGoVersion(versionText)
+		if !ok {
+			tinyGoCheck.skipReason = fmt.Sprintf("could not parse tinygo version from %q", versionText)
+			return
+		}
+		if compareVersions(version, mustParseVersion(MinTinyGoVersion)) < 0 {
+			tinyGoCheck.skipReason = fmt.Sprintf(
+				"tinygo %s installed; plugin build tests require tinygo %s or newer",
+				formatVersion(version),
+				MinTinyGoVersion,
+			)
+		}
+	})
+
+	if tinyGoCheck.skipReason != "" {
+		t.Skip(tinyGoCheck.skipReason)
+	}
+}
+
+type version struct {
+	major int
+	minor int
+	patch int
+}
+
+var tinyGoVersionPattern = regexp.MustCompile(`\btinygo version ([0-9]+)\.([0-9]+)\.([0-9]+)\b`)
+
+func parseTinyGoVersion(output string) (version, bool) {
+	matches := tinyGoVersionPattern.FindStringSubmatch(output)
+	if matches == nil {
+		return version{}, false
+	}
+	major, _ := strconv.Atoi(matches[1])
+	minor, _ := strconv.Atoi(matches[2])
+	patch, _ := strconv.Atoi(matches[3])
+	return version{major: major, minor: minor, patch: patch}, true
+}
+
+func mustParseVersion(s string) version {
+	parts := strings.Split(s, ".")
+	if len(parts) != 3 {
+		panic("invalid version: " + s)
+	}
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		panic("invalid version: " + s)
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		panic("invalid version: " + s)
+	}
+	patch, err := strconv.Atoi(parts[2])
+	if err != nil {
+		panic("invalid version: " + s)
+	}
+	return version{major: major, minor: minor, patch: patch}
+}
+
+func compareVersions(left, right version) int {
+	if left.major != right.major {
+		return left.major - right.major
+	}
+	if left.minor != right.minor {
+		return left.minor - right.minor
+	}
+	return left.patch - right.patch
+}
+
+func formatVersion(v version) string {
+	return fmt.Sprintf("%d.%d.%d", v.major, v.minor, v.patch)
+}

--- a/internal/testutil/tinygo_test.go
+++ b/internal/testutil/tinygo_test.go
@@ -1,0 +1,39 @@
+package testutil
+
+import "testing"
+
+func TestParseTinyGoVersion(t *testing.T) {
+	got, ok := parseTinyGoVersion("tinygo version 0.41.0 darwin/arm64 (using go version go1.26.3)")
+	if !ok {
+		t.Fatal("expected tinygo version to parse")
+	}
+	if got != (version{major: 0, minor: 41, patch: 0}) {
+		t.Fatalf("version = %#v", got)
+	}
+}
+
+func TestCompareVersions(t *testing.T) {
+	min := mustParseVersion(MinTinyGoVersion)
+	for _, tc := range []struct {
+		name string
+		v    version
+		want int
+	}{
+		{name: "older minor", v: version{major: 0, minor: 40, patch: 1}, want: -1},
+		{name: "same", v: version{major: 0, minor: 41, patch: 0}, want: 0},
+		{name: "newer patch", v: version{major: 0, minor: 41, patch: 1}, want: 1},
+		{name: "newer minor", v: version{major: 0, minor: 42, patch: 0}, want: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := compareVersions(tc.v, min)
+			switch {
+			case tc.want < 0 && got >= 0:
+				t.Fatalf("compareVersions(%#v, %#v) = %d, want negative", tc.v, min, got)
+			case tc.want == 0 && got != 0:
+				t.Fatalf("compareVersions(%#v, %#v) = %d, want zero", tc.v, min, got)
+			case tc.want > 0 && got <= 0:
+				t.Fatalf("compareVersions(%#v, %#v) = %d, want positive", tc.v, min, got)
+			}
+		})
+	}
+}

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -9,6 +9,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/mopeyjellyfish/hookr/internal/buildkit"
 	"github.com/mopeyjellyfish/hookr/internal/call"
+	"github.com/mopeyjellyfish/hookr/internal/testutil"
 )
 
 func TestNewModelView(t *testing.T) {
@@ -153,6 +154,8 @@ func TestReadFileModTime(t *testing.T) {
 
 func buildTextFilterSession(t *testing.T) *call.Session {
 	t.Helper()
+	testutil.RequireTinyGo(t)
+
 	dir := t.TempDir()
 	wasmPath := filepath.Join(dir, "textfilter.wasm")
 	buildCfg := buildkit.DefaultConfig()

--- a/testdata/contracts/textfilter/e2e_test.go
+++ b/testdata/contracts/textfilter/e2e_test.go
@@ -8,12 +8,14 @@ import (
 	"time"
 
 	"github.com/mopeyjellyfish/hookr/internal/buildkit"
+	"github.com/mopeyjellyfish/hookr/internal/testutil"
 	"github.com/mopeyjellyfish/hookr/runtime"
 	textfilterhookr "github.com/mopeyjellyfish/hookr/testdata/contracts/textfilter/gen/textfilterhookr"
 )
 
 func TestTextFilterE2E(t *testing.T) {
 	t.Parallel()
+	testutil.RequireTinyGo(t)
 
 	wasmPath := filepath.Join(t.TempDir(), "textfilter.wasm")
 	buildCfg := buildkit.DefaultConfig()
@@ -76,6 +78,7 @@ func TestTextFilterE2E(t *testing.T) {
 
 func TestTextFilterE2E_LiveReload(t *testing.T) {
 	t.Parallel()
+	testutil.RequireTinyGo(t)
 
 	wasmPath := filepath.Join(t.TempDir(), "textfilter.wasm")
 	buildCfg := buildkit.DefaultConfig()

--- a/testdata/contracts/tickloop/benchmark_test.go
+++ b/testdata/contracts/tickloop/benchmark_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/mopeyjellyfish/hookr/internal/buildkit"
+	"github.com/mopeyjellyfish/hookr/internal/testutil"
 	hookrruntime "github.com/mopeyjellyfish/hookr/runtime"
 	tickloophookr "github.com/mopeyjellyfish/hookr/testdata/contracts/tickloop/gen/tickloophookr"
 )
@@ -80,6 +81,8 @@ func BenchmarkTickLoopWarmup(b *testing.B) {
 
 func buildPluginBenchmark(b *testing.B, pluginDir string) string {
 	b.Helper()
+	testutil.RequireTinyGo(b)
+
 	_, filename, _, ok := goruntime.Caller(0)
 	if !ok {
 		b.Fatalf("resolve benchmark file path")

--- a/testdata/contracts/tickloop/e2e_test.go
+++ b/testdata/contracts/tickloop/e2e_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/mopeyjellyfish/hookr/internal/buildkit"
+	"github.com/mopeyjellyfish/hookr/internal/testutil"
 	hookrruntime "github.com/mopeyjellyfish/hookr/runtime"
 	tickloophookr "github.com/mopeyjellyfish/hookr/testdata/contracts/tickloop/gen/tickloophookr"
 	goruntime "runtime"
@@ -191,6 +192,7 @@ func TestTickLoopOpenRejectsTypedNilHostModule(t *testing.T) {
 
 func buildPlugin(t *testing.T, pluginDir string) string {
 	t.Helper()
+	testutil.RequireTinyGo(t)
 
 	_, filename, _, ok := goruntime.Caller(0)
 	if !ok {

--- a/testdata/contracts/urlbalancer/benchmark_test.go
+++ b/testdata/contracts/urlbalancer/benchmark_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/mopeyjellyfish/hookr/internal/buildkit"
+	"github.com/mopeyjellyfish/hookr/internal/testutil"
 	hookrruntime "github.com/mopeyjellyfish/hookr/runtime"
 	urlbalancerhookr "github.com/mopeyjellyfish/hookr/testdata/contracts/urlbalancer/gen/urlbalancerhookr"
 )
@@ -32,6 +33,8 @@ func BenchmarkURLBalancerBalance(b *testing.B) {
 
 func buildURLBalancerBenchmarkPlugin(b *testing.B) string {
 	b.Helper()
+	testutil.RequireTinyGo(b)
+
 	_, filename, _, ok := goruntime.Caller(0)
 	if !ok {
 		b.Fatalf("resolve benchmark file path")

--- a/testdata/contracts/urlbalancer/e2e_test.go
+++ b/testdata/contracts/urlbalancer/e2e_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/mopeyjellyfish/hookr/internal/buildkit"
+	"github.com/mopeyjellyfish/hookr/internal/testutil"
 	hookrruntime "github.com/mopeyjellyfish/hookr/runtime"
 	urlbalancerhookr "github.com/mopeyjellyfish/hookr/testdata/contracts/urlbalancer/gen/urlbalancerhookr"
 )
@@ -22,6 +23,7 @@ func (testHost) Float(_ context.Context, _ *urlbalancerhookr.RngFloatRequestT) (
 
 func TestURLBalancerE2E(t *testing.T) {
 	t.Parallel()
+	testutil.RequireTinyGo(t)
 
 	outFile := filepath.Join(t.TempDir(), "urlbalancer.wasm")
 	cfg := buildkit.DefaultConfig()

--- a/testdata/empty/go.mod
+++ b/testdata/empty/go.mod
@@ -1,3 +1,3 @@
 module github.com/mopeyjellyfish/hookr/testdata/empty
 
-go 1.24.2
+go 1.26

--- a/testdata/simplemethod/go.mod
+++ b/testdata/simplemethod/go.mod
@@ -1,6 +1,6 @@
 module github.com/mopeyjellyfish/hookr/testdata/simplemethod
 
-go 1.24.2
+go 1.26
 
 require github.com/mopeyjellyfish/hookr v1.2.1
 

--- a/testdata/simplemethod_reload/go.mod
+++ b/testdata/simplemethod_reload/go.mod
@@ -1,6 +1,6 @@
 module github.com/mopeyjellyfish/hookr/testdata/simplemethod_reload
 
-go 1.24.2
+go 1.26
 
 require github.com/mopeyjellyfish/hookr v0.0.0
 

--- a/testdata/unsuccessful_call/go.mod
+++ b/testdata/unsuccessful_call/go.mod
@@ -1,3 +1,3 @@
 module github.com/mopeyjellyfish/hookr/testdata/unsuccessful_call
 
-go 1.24.2
+go 1.26


### PR DESCRIPTION
## Summary

- Bump Hookr module, fixture modules, and CI from Go 1.24 to Go 1.26.x.
- Raise the documented plugin-build floor to TinyGo 0.41.0+ and update machine-oriented docs.
- Add a shared TinyGo test guard so plugin-build tests skip on too-old TinyGo instead of failing with Go 1.26.

## Testing

- `go test -count=1 ./...`
- `make build`
- `make test`
- `make lint`
- `make docs/build`
- `go run ./cmd/hookr version`
- `tinygo version` -> `0.41.1 darwin/arm64 (using go version go1.26.3 and LLVM version 20.1.1)`
- `git diff --check`

## Post-Deploy Monitoring & Validation

- Logs / queries: No additional operational monitoring required; this changes build/test/docs metadata and test guards only.
- Metrics / dashboards: No runtime dashboards affected.
- Healthy signal: CI passes on Go 1.26.x and users can install/build plugins in Go 1.26 environments with TinyGo 0.41.0+.
- Failure signal and mitigation trigger: CI setup-go, lint, docs, or TinyGo-backed fixture tests fail; revert or pin the failing toolchain component while investigating.
- Validation window and owner: PR author watches GitHub Actions for this PR.

## Evidence

- Local forced test run built TinyGo-backed fixtures with TinyGo 0.41.1 under Go 1.26.3.
- Pre-commit hook reran runtime lint, runtime tests, and docs build successfully during commit.